### PR TITLE
Fix getExitStatus race condition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildScan {
 }
 
 group = "edu.wpi.first"
-version = "2024.0.0"
+version = "2024.1.0"
 
 base {
     archivesName = "DeployUtils"

--- a/src/main/java/edu/wpi/first/deployutils/deploy/sessions/SshSessionController.java
+++ b/src/main/java/edu/wpi/first/deployutils/deploy/sessions/SshSessionController.java
@@ -74,6 +74,21 @@ public class SshSessionController extends AbstractSessionController implements I
             try {
                 result = IOGroovyMethods.getText(is);
             } finally {
+                // Wait up to 5 seconds for closed
+                // isClosed must be true for getExecStatus to be correct.
+                long start = System.currentTimeMillis();
+                while(!exec.isClosed()) {
+                    long delta = System.currentTimeMillis() - start;
+                    if (delta > 5000) { // 5 seconds
+                        break;
+                    }
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
                 exec.disconnect();
                 release(sem);
             }


### PR DESCRIPTION
We'd been randomly getting -1 status from some tasks. Turns out there is a race condtion in the jsch execute thread, where the thread is completed before the exit code is set. Instead to make this work, you have to wait for isClosed() to be true (The insides of the ssh library are really bad). 

Add a small delay loop with a timeout to make sure this is handled correctly, which removes all these bad status results.