### PR TITLE
Use only password authentication by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildScan {
 }
 
 group = "edu.wpi.first"
-version = "2025.2.1"
+version = "2025.2.2"
 
 base {
     archivesName = "DeployUtils"

--- a/src/main/java/edu/wpi/first/deployutils/deploy/sessions/SshSessionController.java
+++ b/src/main/java/edu/wpi/first/deployutils/deploy/sessions/SshSessionController.java
@@ -13,9 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.sshd.client.auth.password.UserAuthPasswordFactory;
 import org.apache.sshd.client.channel.ClientChannel;
 import org.apache.sshd.client.channel.ClientChannelEvent;
 import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.keyprovider.KeyIdentityProvider;
 import org.apache.sshd.common.util.io.output.NullOutputStream;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.apache.sshd.sftp.client.SftpClientFactory;
@@ -50,6 +52,8 @@ public class SshSessionController extends AbstractSessionController implements I
                 sshConfig.get().execute(localSession);
             } else {
                 localSession.setServerKeyVerifier(new AcceptAllLoggedServerKeyVerifier(getLogger()));
+                localSession.setUserAuthFactories(List.of(UserAuthPasswordFactory.INSTANCE));
+                localSession.setKeyIdentityProvider(KeyIdentityProvider.EMPTY_KEYS_PROVIDER);
                 if (password != null && !password.isBlank()) {
                     localSession.addPasswordIdentity(password);
                 }

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "edu.wpi.first.DeployUtils" version "2025.2.1"
+    id "edu.wpi.first.DeployUtils" version "2025.2.2"
 }
 
 deploy {


### PR DESCRIPTION
Closes https://github.com/wpilibsuite/SystemCoreTesting/issues/161

Set allowed authentication methods to password only, and set the key provider to the empty implementation to prevent it from attempting to open keys at all.