### PR TITLE
Add explicit discovery to SshDiscoveryLocation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ buildScan {
 }
 
 group = "org.wpilib"
-version = "2027.0.0"
+version = "2027.1.0"
 
 base {
     archivesName = "DeployUtils"

--- a/src/main/java/org/wpilib/deployutils/deploy/target/discovery/action/SshDiscoveryAction.java
+++ b/src/main/java/org/wpilib/deployutils/deploy/target/discovery/action/SshDiscoveryAction.java
@@ -35,6 +35,7 @@ public class SshDiscoveryAction extends AbstractDiscoveryAction {
     @Override
     public DeployContext discover() {
         SshDeployLocation location = sshLocation();
+        location.discover();
         RemoteTarget target = location.getTarget();
         String address = location.getAddress();
         log = ETLoggerFactory.INSTANCE.create("SshDiscoverAction[" + address + "]");

--- a/src/main/java/org/wpilib/deployutils/deploy/target/location/SshDeployLocation.java
+++ b/src/main/java/org/wpilib/deployutils/deploy/target/location/SshDeployLocation.java
@@ -87,4 +87,6 @@ public class SshDeployLocation extends AbstractDeployLocation {
         return "SshDeployLocation[" + friendlyString() + "]";
     }
 
+    public void discover() {
+    }
 }

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.wpilib.DeployUtils" version "2027.0.0"
+    id "org.wpilib.DeployUtils" version "2027.1.0"
 }
 
 deploy {


### PR DESCRIPTION
This makes it so much easier to handle errors properly and give better error messages in the output. Additionally removes a double socket check on failure